### PR TITLE
fix: correct logical condition in sendCommandToElectron function to e…

### DIFF
--- a/src/utils/electron-enhanced-commands.ts
+++ b/src/utils/electron-enhanced-commands.ts
@@ -423,7 +423,7 @@ export async function sendCommandToElectron(command: string, args?: CommandArgs)
               if (result === null) {
                 return { success: false, error: 'Command returned null - element may not exist', result: null };
               }
-              if (result === false && rawCode.includes('click') || rawCode.includes('querySelector')) {
+              if (result === false && (rawCode.includes('click') || rawCode.includes('querySelector'))) {
                 return { success: false, error: 'Command returned false - action likely failed', result: false };
               }
               


### PR DESCRIPTION
## Fix Operator Precedence Bug

### Problem

Line 426 in `src/utils/electron-enhanced-commands.ts` contains an operator precedence bug.

**Before:**

```ts
if (result === false && rawCode.includes('click') || rawCode.includes('querySelector')) {
```

Due to `&&` having higher precedence than `||`, the actual logic evaluates as:

```ts
(result === false && rawCode.includes('click')) || rawCode.includes('querySelector')
```

This means any code containing `querySelector` would return failure regardless of the `result` value, causing false negatives for successful commands.

### Fix

Add parentheses to enforce the intended grouping.

**After:**

```ts
if (result === false && (rawCode.includes('click') || rawCode.includes('querySelector'))) {
```

Now it only returns failure when `result === false` and the code contains either `click` or `querySelector`, matching the original intent.

### Changes

- `src/utils/electron-enhanced-commands.ts`: 1 line modified

### Testing Notes

- Verify successful commands with `querySelector` no longer incorrectly report failure
- Verify `result === false` with `click` still correctly returns failure
- Verify `result === false` with `querySelector` still correctly returns failure
